### PR TITLE
Explicit way of dealing with JSON data in POST body params

### DIFF
--- a/lcrs_embedded/data/index.html
+++ b/lcrs_embedded/data/index.html
@@ -22,13 +22,13 @@
     </select>
     <br><br>
 
-    <textarea name="data">
-    {
-      "blah": 123,
-    }
-    </textarea>
+<textarea name="data">
+{
+  "blah": 123
+}
+</textarea>
 
-    <button type="button" onclick="this.form.action=this.form.commandwhatever.value; this.form.submit()">SEND</button>
+    <button type="button" onclick="this.form.action=this.form.commandwhatever.value + '?json_param=data'; this.form.submit()">SEND</button>
 
   </form>
 

--- a/lcrs_embedded/server.py
+++ b/lcrs_embedded/server.py
@@ -115,9 +115,16 @@ class LCRSRequestHandler(JSONRequestHandler):
                     )
                 )
                 return
-            except KeyError:
+            except (KeyError, TypeError):
                 self.respond_object(
-                    models.StateResponse(state_id=self.server.lcrs_state)
+                    models.StateResponse(
+                        state_id=self.server.lcrs_state,
+                        job_response=models.JobResponse(
+                            job_id=job_id,
+                            progress=0,
+                            status=protocol.JOB_UNKNOWN,
+                        )
+                    )
                 )
                 return
         self.respond_object(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import time
 from threading import ThreadError
@@ -53,6 +54,23 @@ def test_status_busy_api(runserver):
         )
         assert status.job_response.progress <= i
         time.sleep(i)
+
+
+def test_api_json_in_post_data(runserver):
+    """
+    This test ensures that we keep support having data=<json data> as the
+    request body for a POST request.
+    """
+    logger.info("Testing the API status...")
+
+    response = utils.request_api_endpoint(
+        "/api/v1/status/?json_param=data",
+        raw_body={'data': json.dumps({'job_id': 3})},
+    )
+    json_response = json.loads(response.content.decode("utf-8"))
+    job_response = json_response['job_response']
+    assert job_response['job_id'] > 0
+    assert job_response['status'] == protocol.JOB_UNKNOWN
 
 
 def test_fail_api(runserver):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -22,12 +22,16 @@ def get_url(urlpath):
     return "http://{}:{}{}".format(SERVER_HOST, SERVER_TEST_PORT, urlpath)
 
 
-def request_api_endpoint(urlpath, data=None):
+def request_api_endpoint(urlpath, data=None, raw_body=None):
     with assert_no_thread_exceptions():
         url = get_url(urlpath)
         logger.debug("Testing API endpoint, url: {}".format(url))
         try:
-            response = requests.post(url, json=data)
+            if raw_body:
+                kwargs = {'data': raw_body}
+            else:
+                kwargs = {'json': data}
+            response = requests.post(url, **kwargs)
             if not response.status_code == 200:
                 raise WrongStatusCode("Status code was {}".format(
                     response.status_code


### PR DESCRIPTION
Was using browser interface for posting JSON data to API, and this was broken. Adding tests and making interface more explicit.

Fixes current master failure.

@jvilladsen - want to review? :)