### PR TITLE
Add function that generates CPU load, third attempt

### DIFF
--- a/lcrs_embedded/models.py
+++ b/lcrs_embedded/models.py
@@ -65,6 +65,7 @@ class ScanResult(Response):
     processor_cores = None
     #: Raw, unparsed model name from cpuinfo
     processor_model_name = None
+    processor_load_status = None
 
     battery = None
 

--- a/lcrs_embedded/system/cpu_load.py
+++ b/lcrs_embedded/system/cpu_load.py
@@ -7,30 +7,45 @@ import time
 
 logger = logging.getLogger(__name__)
 
-def multiple_processes_load_cpu(scan_result, duration_in_seconds):
+def timed_cpu_load(endTime):
     """
-    Start a number of processes that each do simple arithmetics to
-    generate a load on the CPU for a number of seconds.
+    Add some numbers for a while.
+    Could have been placed inside cpu_load below but there it
+    is called within a separate process and is then not picked
+    up in test coverage. Solved with a direct call in the test.
     """
-    def load_cpu():
-        """
-        Not using range(count) as that would put load on memory.
-        """
-        m = 1
-        running = True
-        while running:
-            m = (m + 1) % 100000
-            running = (m != 0) or (int(time.time()) - startTime < duration_in_seconds)
+    m = 1
+    running = True
+    while running:
+        m = (m + 1) % 100000
+        running = (m != 0) or (time.time() < endTime)
+
+def cpu_load(scan_result, duration_in_seconds):
+    """
+    Load CPU.
+    """
     
-    number_of_processes = scan_result.processor_cores
+    def multiple_processes_load_cpu(duration_in_seconds):
+        """
+        Start a number of processes that each do simple arithmetics to
+        generate a load on the CPU for a number of seconds.
+        """
+        number_of_processes = scan_result.processor_cores
+        
+        startTime = time.time()
+        endTime = startTime + duration_in_seconds
+        logger.info("Starting to generate load on CPU, time {}".format(startTime))
+        processes = []
+        for n in range(number_of_processes):
+            process = Process(target = timed_cpu_load, args = (endTime,))
+            process.start()
+            processes.append(process)
+        for n in range(number_of_processes):
+            processes[n].join()
+        logger.info("Finished generating load on CPU, time {}".format(time.time()))
     
-    startTime = int(time.time())
-    logger.info("Starting to generate load on CPU, time {}".format(startTime))
-    processes = []
-    for n in range(number_of_processes):
-        process = Process(target = load_cpu, args = ( ))
-        process.start()
-        processes.append(process)
-    for n in range(number_of_processes):
-        processes[n].join()
-    logger.info("Finished generating load on CPU, time {}".format(int(time.time())))
+    try:
+        multiple_processes_load_cpu(duration_in_seconds)
+        scan_result.processor_load_status = "Complete"
+    except Exception as e:
+        scan_result.processor_load_status = "Failed: %s %s" % (type(e), e)

--- a/lcrs_embedded/system/cpu_load.py
+++ b/lcrs_embedded/system/cpu_load.py
@@ -34,13 +34,3 @@ def multiple_processes_load_cpu(scan_result, duration_in_seconds):
     for n in range(number_of_processes):
         processes[n].join()
     logger.info("Finished generating load on CPU, time {}".format(int(time.time())))
-
-
-if __name__ == "__main__":
-    from lcrs_embedded.models import ScanResult
-    
-    scan_result = ScanResult(
-        processor_cores=2
-    )
-    multiple_processes_load_cpu(scan_result, 10)
-    

--- a/lcrs_embedded/system/cpu_load.py
+++ b/lcrs_embedded/system/cpu_load.py
@@ -1,0 +1,46 @@
+"""
+Generate a load on the CPU with one process per core.
+"""
+import logging
+from multiprocessing import Process
+import time
+
+logger = logging.getLogger(__name__)
+
+def multiple_processes_load_cpu(scan_result, duration_in_seconds):
+    """
+    Start a number of processes that each do simple arithmetics to
+    generate a load on the CPU for a number of seconds.
+    """
+    def load_cpu():
+        """
+        Not using range(count) as that would put load on memory.
+        """
+        m = 1
+        running = True
+        while running:
+            m = (m + 1) % 100000
+            running = (m != 0) or (int(time.time()) - startTime < duration_in_seconds)
+    
+    number_of_processes = scan_result.processor_cores
+    
+    startTime = int(time.time())
+    logger.info("Starting to generate load on CPU, time {}".format(startTime))
+    processes = []
+    for n in range(number_of_processes):
+        process = Process(target = load_cpu, args = ( ))
+        process.start()
+        processes.append(process)
+    for n in range(number_of_processes):
+        processes[n].join()
+    logger.info("Finished generating load on CPU, time {}".format(int(time.time())))
+
+
+if __name__ == "__main__":
+    from lcrs_embedded.models import ScanResult
+    
+    scan_result = ScanResult(
+        processor_cores=2
+    )
+    multiple_processes_load_cpu(scan_result, 10)
+    

--- a/tests/test_cpu_load.py
+++ b/tests/test_cpu_load.py
@@ -1,0 +1,25 @@
+import pytest
+import logging
+import time
+
+from lcrs_embedded.models import ScanResult
+from . import *  # noqa  # This loads the fixtures that are in __init__.py
+
+logger = logging.getLogger(__name__)
+
+
+def test_cpu_load(runserver):
+    """
+    Test duration of load of CPU.
+    """
+    from lcrs_embedded.system.cpu_load import multiple_processes_load_cpu
+    logger.info("Testing duration of load of CPU...")
+    duration_in_seconds = 1
+    startTime = int(time.time())
+    scan_result = ScanResult(
+        processor_cores=1
+    )
+    multiple_processes_load_cpu(scan_result, duration_in_seconds)
+    actual_duration = int(time.time()) - startTime
+    assert actual_duration >= duration_in_seconds
+    assert actual_duration <= duration_in_seconds + 1

--- a/tests/test_cpu_load.py
+++ b/tests/test_cpu_load.py
@@ -12,14 +12,29 @@ def test_cpu_load(runserver):
     """
     Test duration of load of CPU.
     """
-    from lcrs_embedded.system.cpu_load import multiple_processes_load_cpu
-    logger.info("Testing duration of load of CPU...")
+    from lcrs_embedded.system.cpu_load import cpu_load
+    logger.info("Testing duration of load of CPU with two cores")
     duration_in_seconds = 1
-    startTime = int(time.time())
+    startTime = time.time()
     scan_result = ScanResult(
-        processor_cores=1
+        processor_cores=2
     )
-    multiple_processes_load_cpu(scan_result, duration_in_seconds)
-    actual_duration = int(time.time()) - startTime
+    cpu_load(scan_result, duration_in_seconds)
+    actual_duration = time.time() - startTime
+    assert actual_duration >= duration_in_seconds
+    assert actual_duration <= duration_in_seconds + 1
+    assert scan_result.processor_load_status == "Complete"
+
+def test_timed_cpu_load(runserver):
+    """
+    Test duration of load of CPU with a call in same process.
+    """
+    from lcrs_embedded.system.cpu_load import timed_cpu_load
+    logger.info("Testing duration of load of CPU with one core")
+    duration_in_seconds = 3
+    startTime = time.time()
+    endTime = startTime + duration_in_seconds
+    timed_cpu_load(endTime)
+    actual_duration = time.time() - startTime
     assert actual_duration >= duration_in_seconds
     assert actual_duration <= duration_in_seconds + 1


### PR DESCRIPTION
Add a test of the timed CPU load from within the same process so that this is picked up in test coverage.
Measure duration in timed CPU load and test as float.
Processor load status field added to the scan result.